### PR TITLE
feat: añadir plantilla base con navegación

### DIFF
--- a/circulos/ayuda-safari.html
+++ b/circulos/ayuda-safari.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <div class="container">
     <h1>🔧 Ayuda para Safari</h1>
     

--- a/circulos/circulo-coding.html
+++ b/circulos/circulo-coding.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <div class="header">
     <img src="logo.png" alt="Logo Asperger para Asperger" class="header-logo">
     <div class="header-content">

--- a/circulos/circulo-emprendimiento.html
+++ b/circulos/circulo-emprendimiento.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <div class="header">
     <img src="logo.png" alt="Logo Asperger para Asperger" class="header-logo">
     <div class="header-content">

--- a/circulos/circulo-espanol.html
+++ b/circulos/circulo-espanol.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <div class="header">
     <img src="logo.png" alt="Logo Asperger para Asperger" class="header-logo">
     <div class="header-content">

--- a/circulos/circulo-lectura.html
+++ b/circulos/circulo-lectura.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <div class="header">
     <img src="logo.png" alt="Logo Asperger para Asperger" class="header-logo">
     <div class="header-content">

--- a/circulos/circulo-marketing.html
+++ b/circulos/circulo-marketing.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <div class="header">
     <img src="logo.png" alt="Logo Asperger para Asperger" class="header-logo">
     <div class="header-content">

--- a/circulos/circulo-pensamiento.html
+++ b/circulos/circulo-pensamiento.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <div class="header">
     <img src="logo.png" alt="Logo Asperger para Asperger" class="header-logo">
     <div class="header-content">

--- a/circulos/circulo-social.html
+++ b/circulos/circulo-social.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <div class="header">
     <img src="logo.png" alt="Logo Asperger para Asperger" class="header-logo">
     <div class="header-content">

--- a/circulos/landing-circulos.html
+++ b/circulos/landing-circulos.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <div class="header">
     <img src="logo.png" alt="Logo Asperger para Asperger" class="header-logo">
     <div class="header-content">

--- a/circulos/test-enlaces.html
+++ b/circulos/test-enlaces.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <h1>Test de Enlaces para Safari</h1>
   
   <h2>Enlaces Relativos:</h2>

--- a/libros/001/pantalla_principal.html
+++ b/libros/001/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">ApA</div>

--- a/libros/001N/pantalla_principal.html
+++ b/libros/001N/pantalla_principal.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="nuevo-style.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="main-header">
     <div class="logo-container">
       <div class="logo">EFJ</div>

--- a/libros/002/pantalla_principal.html
+++ b/libros/002/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">OpR</div>

--- a/libros/002N/pantalla_principal.html
+++ b/libros/002N/pantalla_principal.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="nuevo-style.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="main-header">
     <div class="logo-container">
       <div class="logo">OJ</div>

--- a/libros/003/pantalla_principal.html
+++ b/libros/003/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">PyR</div>

--- a/libros/003N/pantalla_principal.html
+++ b/libros/003N/pantalla_principal.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="nuevo-style.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="main-header">
     <div class="logo-container">
       <div class="logo">PyRJ</div>

--- a/libros/004/pantalla_principal.html
+++ b/libros/004/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">IR</div>

--- a/libros/004N/pantalla_principal.html
+++ b/libros/004N/pantalla_principal.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="nuevo-style.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="main-header">
     <div class="logo-container">
       <div class="logo">IJ</div>

--- a/libros/005/pantalla_principal.html
+++ b/libros/005/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">¿?</div>

--- a/libros/005N/pantalla_principal.html
+++ b/libros/005N/pantalla_principal.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" href="nuevo-style.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
     <div class="container">
         <header class="main-header">
             <div class="logo-container"><span class="logo">Y</span></div>

--- a/libros/006/pantalla_principal.html
+++ b/libros/006/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">🐸</div>

--- a/libros/007/pantalla_principal.html
+++ b/libros/007/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">LV</div>

--- a/libros/008/pantalla_principal.html
+++ b/libros/008/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">MF</div>

--- a/libros/009/pantalla_principal.html
+++ b/libros/009/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">MBA</div>

--- a/libros/010/pantalla_principal.html
+++ b/libros/010/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">🧠</div>

--- a/libros/011/pantalla_principal.html
+++ b/libros/011/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">👑</div>

--- a/libros/012/pantalla_principal.html
+++ b/libros/012/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">🧠</div>

--- a/libros/013/pantalla_principal.html
+++ b/libros/013/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">⭐</div>

--- a/libros/014/pantalla_principal.html
+++ b/libros/014/pantalla_principal.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">🔄</div>

--- a/libros/015/pantalla_principal.html
+++ b/libros/015/pantalla_principal.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">⚡</div>

--- a/libros/016/pantalla_principal.html
+++ b/libros/016/pantalla_principal.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">🧠</div>

--- a/libros/017/pantalla_principal.html
+++ b/libros/017/pantalla_principal.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">⚡</div>

--- a/libros/018/pantalla_principal.html
+++ b/libros/018/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">⭐</div>

--- a/libros/019/pantalla_principal.html
+++ b/libros/019/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">🧠</div>

--- a/libros/020/pantalla_principal.html
+++ b/libros/020/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">⭐</div>

--- a/libros/021/pantalla_principal.html
+++ b/libros/021/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">⭐</div>

--- a/libros/022/pantalla_principal.html
+++ b/libros/022/pantalla_principal.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">🏆</div>

--- a/libros/023/pantalla_principal.html
+++ b/libros/023/pantalla_principal.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="/static/css/main.css">
 </head>
 <body>
+  <div id="site-header"></div>
+  <script src="/static/js/load-header.js"></script>
   <header class="header">
     <div class="logo-container">
       <div class="logo">🎯</div>

--- a/static/js/load-header.js
+++ b/static/js/load-header.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const container = document.getElementById('site-header');
+  if (container) {
+    fetch('/templates/base.html')
+      .then(response => response.text())
+      .then(data => {
+        container.innerHTML = data;
+      })
+      .catch(err => console.error('Error cargando la cabecera:', err));
+  }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,45 @@
+<header class="site-header">
+  <nav class="main-nav">
+    <a href="/circulos/landing-circulos.html">Inicio</a>
+    <a href="/circulos/circulo-coding.html">Círculo Coding e IA</a>
+    <a href="/circulos/circulo-emprendimiento.html">Círculo Emprendimiento</a>
+    <a href="/circulos/circulo-espanol.html">Círculo Español</a>
+    <a href="/circulos/circulo-lectura.html">Círculo Lectura</a>
+    <a href="/circulos/circulo-marketing.html">Círculo Marketing</a>
+    <a href="/circulos/circulo-pensamiento.html">Círculo Pensamiento</a>
+    <a href="/circulos/circulo-social.html">Círculo Social</a>
+    <a href="/libros/001/pantalla_principal.html">Cómo Piensan los Ricos</a>
+    <a href="/libros/001N/pantalla_principal.html">Educación Financiera Joven</a>
+    <a href="/libros/002/pantalla_principal.html">El Optimista Racional</a>
+    <a href="/libros/002N/pantalla_principal.html">Optimismo Joven</a>
+    <a href="/libros/003/pantalla_principal.html">Piense y Hágase Rico</a>
+    <a href="/libros/003N/pantalla_principal.html">Piense y Hágase Rico Joven</a>
+    <a href="/libros/004/pantalla_principal.html">Inquebrantable</a>
+    <a href="/libros/004N/pantalla_principal.html">Inquebrantable Joven</a>
+    <a href="/libros/005/pantalla_principal.html">Comienza con el Por Qué</a>
+    <a href="/libros/005N/pantalla_principal.html">¡Empieza con tu Porqué!</a>
+    <a href="/libros/006/pantalla_principal.html">¡Tráguese ese Sapo!</a>
+    <a href="/libros/007/pantalla_principal.html">La Vaca de Camilo Cruz</a>
+    <a href="/libros/008/pantalla_principal.html">El monje que vendió su Ferrari</a>
+    <a href="/libros/009/pantalla_principal.html">El MBA Personal</a>
+    <a href="/libros/010/pantalla_principal.html">Atrévete a no gustar</a>
+    <a href="/libros/011/pantalla_principal.html">El Líder que no Tenía Cargo</a>
+    <a href="/libros/012/pantalla_principal.html">La Quinta Disciplina</a>
+    <a href="/libros/013/pantalla_principal.html">Los 7 Hábitos</a>
+    <a href="/libros/014/pantalla_principal.html">El Poder de los Hábitos</a>
+    <a href="/libros/015/pantalla_principal.html">Hábitos Atómicos</a>
+    <a href="/libros/016/pantalla_principal.html">El Cerebro que se Cambia a Sí Mismo</a>
+    <a href="/libros/017/pantalla_principal.html">El Efecto Compuesto</a>
+    <a href="/libros/018/pantalla_principal.html">The Slight Edge</a>
+    <a href="/libros/019/pantalla_principal.html">Mentalidad</a>
+    <a href="/libros/020/pantalla_principal.html">De Bueno a Excelente</a>
+    <a href="/libros/021/pantalla_principal.html">El Pequeño Libro del Talento</a>
+    <a href="/libros/022/pantalla_principal.html">Número Uno</a>
+    <a href="/libros/023/pantalla_principal.html">Céntrate (Deep Work)</a>
+  </nav>
+</header>
+<style>
+.site-header{background:#333;padding:10px;}
+.site-header .main-nav a{color:#fff;margin-right:10px;text-decoration:none;}
+.site-header .main-nav a:hover{text-decoration:underline;}
+</style>


### PR DESCRIPTION
## Summary
- crear plantilla base con cabecera y menú de enlaces a círculos y libros
- cargar la cabecera desde JavaScript para reutilizarla en todas las páginas
- actualizar páginas de círculos y libros para incluir el menú común

## Testing
- `python - <<'PY'
import re, os
with open('templates/base.html') as f:
    html = f.read()
links = re.findall(r'href="([^"]+)"', html)
missing=[]
for link in links:
    path=link.lstrip('/')
    if not os.path.exists(path):
        missing.append(link)
print('Missing:', missing)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689b5e81247883219e10061d438619c0